### PR TITLE
Fix Dutch translation typo

### DIFF
--- a/client/src/translations/nl.ts
+++ b/client/src/translations/nl.ts
@@ -35,7 +35,7 @@ export const nl = {
     },
     workflow: {
       title: 'Hoe We Werken',
-      subtitle: 'Wij combineren creatieve innovatie met zakelijk inzicht om applicaties te onwikkelen die visueel aantrekkelijk én functioneel krachtig zijn — en zorgen voor uitzonderlijke gebruikerservaringen die echte resultaten opleveren.',
+      subtitle: 'Wij combineren creatieve innovatie met zakelijk inzicht om applicaties te ontwikkelen die visueel aantrekkelijk én functioneel krachtig zijn — en zorgen voor uitzonderlijke gebruikerservaringen die echte resultaten opleveren.',
       step1: {
         title: 'Verkenning',
         content: 'We verkennen jouw visie en zakelijke uitdagingen om kansen te ontdekken voor slimme digitale oplossingen.'


### PR DESCRIPTION
## Summary
- fix typo in Dutch workflow subtitle

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*